### PR TITLE
Refine backend layout for AdminLTE 4

### DIFF
--- a/backend/views/layouts/main.php
+++ b/backend/views/layouts/main.php
@@ -75,7 +75,7 @@ $homeUrl = is_string(Yii::$app->homeUrl) ? Yii::$app->homeUrl : '/';
         <div class="container-fluid">
             <ul class="navbar-nav">
                 <li class="nav-item">
-                    <button type="button" class="btn btn-link nav-link" data-lte-toggle="sidebar" aria-label="<?= Yii::t('app', 'Toggle sidebar') ?>">
+                    <button type="button" class="btn btn-link nav-link" data-lte-toggle="sidebar" aria-controls="app-sidebar" aria-expanded="false" aria-label="<?= Yii::t('app', 'Toggle sidebar') ?>">
                         <i class="fas fa-bars"></i>
                     </button>
                 </li>
@@ -153,35 +153,38 @@ $homeUrl = is_string(Yii::$app->homeUrl) ? Yii::$app->homeUrl : '/';
         </div>
     </nav>
 
-    <aside class="app-sidebar bg-body-secondary shadow" data-bs-theme="dark" aria-label="<?= Yii::t('app', 'Sidebar menu') ?>">
-        <div class="app-sidebar-header d-flex align-items-center justify-content-between px-3 py-2">
-            <a href="<?= $homeUrl ?>" class="app-sidebar-brand text-decoration-none text-white fw-semibold">
-                <span><?= Html::encode(Yii::$app->name) ?></span>
-            </a>
-            <button class="btn btn-link text-white" data-lte-toggle="sidebar" aria-label="<?= Yii::t('app', 'Close sidebar') ?>">
-                <i class="fas fa-times"></i>
-            </button>
-        </div>
-        <div class="app-sidebar-body px-3 pb-3" id="sidebar-menu">
-            <div class="d-flex align-items-center mb-3">
-                <div class="me-2">
-                    <?= AvatarWidget::widget([
-                        'user_id' => $user->id,
-                        'imageOptions' => [
-                            'class' => 'rounded-circle sidebar-user-image'
-                        ]
-                    ]) ?>
-                </div>
-                <div>
-                    <p class="mb-0 fw-semibold text-white"><?= $fullUserName ?></p>
-                    <span class="text-success small"><i class="fas fa-circle me-1"></i><?= Yii::t('app', 'Online') ?></span>
-                </div>
+    <aside class="app-sidebar bg-body-secondary shadow" id="app-sidebar" data-bs-theme="dark" aria-label="<?= Yii::t('app', 'Sidebar menu') ?>">
+        <div class="app-sidebar-content h-100 d-flex flex-column">
+            <div class="app-sidebar-header d-flex align-items-center justify-content-between px-3 py-3 border-bottom border-dark-subtle">
+                <a href="<?= $homeUrl ?>" class="app-sidebar-brand text-decoration-none text-white fw-semibold d-flex align-items-center gap-2">
+                    <i class="fas fa-layers"></i>
+                    <span><?= Html::encode(Yii::$app->name) ?></span>
+                </a>
+                <button class="btn btn-link text-white" data-lte-toggle="sidebar" aria-controls="app-sidebar" aria-expanded="true" aria-label="<?= Yii::t('app', 'Close sidebar') ?>">
+                    <i class="fas fa-times"></i>
+                </button>
             </div>
+            <div class="app-sidebar-body flex-grow-1 px-3 py-4" id="sidebar-menu">
+                <div class="d-flex align-items-center mb-4">
+                    <div class="me-2">
+                        <?= AvatarWidget::widget([
+                            'user_id' => $user->id,
+                            'imageOptions' => [
+                                'class' => 'rounded-circle sidebar-user-image'
+                            ]
+                        ]) ?>
+                    </div>
+                    <div class="text-white">
+                        <p class="mb-0 fw-semibold"><?= $fullUserName ?></p>
+                        <span class="text-success small"><i class="fas fa-circle me-1"></i><?= Yii::t('app', 'Online') ?></span>
+                    </div>
+                </div>
 
-            <?= SearchSidebar::widget(['status' => true]) ?>
+                <?= SearchSidebar::widget(['status' => true]) ?>
 
-            <?php
-            $items = [
+                <nav class="app-sidebar-menu" aria-label="<?= Yii::t('app', 'Sidebar navigation') ?>">
+                    <?php
+                    $items = [
                 [
                     'label' => Yii::t('app', 'HEADER'),
                     'options' => ['class' => 'nav-header text-uppercase text-muted small']
@@ -279,26 +282,35 @@ $homeUrl = is_string(Yii::$app->homeUrl) ? Yii::$app->homeUrl : '/';
                     ]
                 ]
             ];
-            echo \yii\widgets\Menu::widget([
-                'options' => [
-                    'class' => 'nav nav-pills nav-sidebar flex-column',
-                    'data-lte-toggle' => 'treeview',
-                    'role' => 'menu',
-                    'data-accordion' => 'false'
-                ],
-                'itemOptions' => ['class' => 'nav-item'],
-                'linkTemplate' => '<a href="{url}" class="nav-link">{label}</a>', // deja solo esto
-                // 'activeLinkTemplate' => '<a href="{url}" class="nav-link active">{label}</a>', // <- QUITAR
-                'encodeLabels' => false,
-                'submenuTemplate' => "\n<ul class=\"nav nav-treeview\" role=\"menu\">\n{items}\n</ul>\n",
-                'activateParents' => true,
-                'activeCssClass' => 'active',  // Yii pondrá 'active' en el <li>
-                'items' => $items
-            ]);
-
-            ?>
+                    echo \yii\widgets\Menu::widget([
+                        'options' => [
+                            'class' => 'nav nav-pills nav-sidebar flex-column gap-1',
+                            'data-lte-toggle' => 'treeview',
+                            'role' => 'menu',
+                            'id' => 'app-sidebar-menu-list',
+                            'aria-multiselectable' => 'true',
+                            'data-accordion' => 'false'
+                        ],
+                        'itemOptions' => ['class' => 'nav-item'],
+                        'linkTemplate' => '<a href="{url}" class="nav-link">{label}</a>',
+                        'encodeLabels' => false,
+                        'submenuTemplate' => "\n<ul class=\"nav nav-treeview\" role=\"group\">\n{items}\n</ul>\n",
+                        'activateParents' => true,
+                        'activeCssClass' => 'active',
+                        'items' => $items
+                    ]);
+                    ?>
+                </nav>
+            </div>
+            <div class="app-sidebar-footer px-3 py-3 border-top border-dark-subtle text-white-50 small">
+                <div class="d-flex align-items-center justify-content-between">
+                    <span><?= Yii::t('app', 'Logged in as') ?></span>
+                    <span class="fw-semibold text-white"><?= Html::encode($identity ? $identity->username : Yii::t('app', 'Guest')) ?></span>
+                </div>
+            </div>
         </div>
     </aside>
+    <div class="app-sidebar-overlay" data-lte-toggle="sidebar" aria-hidden="true"></div>
 
     <main class="app-main" id="main-content">
         <div class="app-content-header border-bottom">

--- a/backend/web/css/site.css
+++ b/backend/web/css/site.css
@@ -5,6 +5,28 @@ h1, h2, h3, h4, h5, h6,
     font-family: "Source Sans Pro Regular", sans-serif;
 }
 
+.app-wrapper {
+    min-height: 100vh;
+}
+
+.app-header .navbar-brand {
+    font-weight: 600;
+    color: inherit;
+}
+
+.app-header .navbar-brand:hover,
+.app-header .navbar-brand:focus {
+    color: var(--bs-primary);
+}
+
+.app-header .dropdown-menu-lg {
+    min-width: 20rem;
+}
+
+.app-header .dropdown-footer a {
+    font-weight: 500;
+}
+
 .title-column {
     text-align: center;
 }
@@ -33,11 +55,34 @@ button::-moz-focus-inner {
     border: 0 !important;
 }
 
+.app-sidebar {
+    width: 280px;
+}
+
+.app-sidebar-content {
+    min-height: 100%;
+}
+
+.app-sidebar-body {
+    overflow-y: auto;
+}
+
+.app-sidebar .sidebar-user-image {
+    width: 44px;
+    height: 44px;
+    object-fit: cover;
+}
+
+.app-sidebar .nav-sidebar {
+    padding: 0;
+}
+
 .app-sidebar .nav-sidebar .nav-link {
     color: inherit;
     display: flex;
     align-items: center;
     gap: .75rem;
+    transition: background-color .2s ease, color .2s ease;
 }
 
 .app-sidebar .nav-sidebar .nav-link .nav-icon {
@@ -57,8 +102,14 @@ button::-moz-focus-inner {
     color: var(--bs-primary);
 }
 
+.app-sidebar .nav-sidebar > .nav-item > .nav-treeview {
+    margin-left: 2.5rem;
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+    padding-left: 1rem;
+}
+
 .app-sidebar .nav-treeview .nav-link {
-    padding-left: 2.5rem;
+    padding-left: 1rem;
     font-size: .95rem;
 }
 
@@ -67,10 +118,55 @@ button::-moz-focus-inner {
     letter-spacing: .08em;
 }
 
-.app-sidebar .sidebar-user-image {
-    width: 44px;
-    height: 44px;
-    object-fit: cover;
+.app-sidebar[data-bs-theme="dark"] .app-sidebar-brand {
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+}
+
+.app-sidebar[data-bs-theme="dark"] .app-sidebar-brand:hover,
+.app-sidebar[data-bs-theme="dark"] .app-sidebar-brand:focus {
+    color: #fff;
+}
+
+.app-sidebar[data-bs-theme="dark"] .app-sidebar-brand i {
+    font-size: 1.125rem;
+}
+
+.app-sidebar[data-bs-theme="dark"] .sidebar-search .form-control {
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 0;
+    color: #fff;
+}
+
+.app-sidebar[data-bs-theme="dark"] .sidebar-search .form-control::placeholder {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.app-sidebar[data-bs-theme="dark"] .sidebar-search .btn {
+    border: 0;
+    color: #fff;
+}
+
+.app-sidebar .app-sidebar-footer {
+    font-size: .85rem;
+}
+
+.app-sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .3s ease, visibility .3s ease;
+    z-index: 1034;
+}
+
+body.sidebar-open .app-sidebar-overlay {
+    opacity: 1;
+    visibility: visible;
 }
 
 .app-header .user-image {
@@ -79,14 +175,20 @@ button::-moz-focus-inner {
     object-fit: cover;
 }
 
-.app-header .dropdown-menu-lg {
-    min-width: 20rem;
-}
-
-.app-header .dropdown-footer a {
-    font-weight: 500;
-}
-
 .app-page-title small {
     font-size: 0.75em;
+}
+
+@media (max-width: 991.98px) {
+    .app-sidebar {
+        width: 100%;
+    }
+
+    .app-sidebar-body {
+        padding-bottom: 3rem;
+    }
+
+    body.sidebar-open {
+        overflow: hidden;
+    }
 }


### PR DESCRIPTION
## Summary
- refresh the backend main layout to follow AdminLTE 4 / Bootstrap 5 structure, adding accessible sidebar toggles and overlay support
- wrap the sidebar navigation in a dedicated container with footer metadata for the signed-in user
- extend the backend stylesheet with responsive and dark-theme friendly sidebar styling updates

## Testing
- php -l backend/views/layouts/main.php

------
https://chatgpt.com/codex/tasks/task_e_68da9eca46b4832eab7d44b6eac35392