### PR TITLE
Refine backend dashboard styling for AdminLTE 4

### DIFF
--- a/backend/web/css/site.css
+++ b/backend/web/css/site.css
@@ -2,13 +2,13 @@
 
 :root {
     --app-sidebar-width: 280px;
-    --app-sidebar-bg: #111827;
-    --app-sidebar-bg-gradient: linear-gradient(180deg, #1f2937 0%, #111827 100%);
+    --app-sidebar-bg: #0f172a;
+    --app-sidebar-bg-gradient: linear-gradient(180deg, #1f2937 0%, #0f172a 100%);
     --app-sidebar-color: #f8fafc;
     --app-sidebar-muted: rgba(248, 250, 252, 0.65);
     --app-sidebar-border: rgba(148, 163, 184, 0.22);
-    --app-header-height: 3.5rem;
-    --app-card-shadow: 0 0.5rem 1.5rem rgba(15, 23, 42, 0.08);
+    --app-header-height: 3.75rem;
+    --app-card-shadow: 0 1.25rem 2.75rem rgba(15, 23, 42, 0.12);
 }
 
 body,
@@ -45,13 +45,16 @@ a:focus {
 
 .app-wrapper {
     min-height: 100vh;
-    background-image: linear-gradient(135deg, rgba(var(--bs-primary-rgb), 0.05), transparent 60%);
+    background-image: linear-gradient(135deg, rgba(var(--bs-primary-rgb), 0.06), transparent 65%),
+        radial-gradient(circle at top right, rgba(56, 189, 248, 0.15), transparent 55%);
 }
 
 .app-header {
     min-height: var(--app-header-height);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    background: rgba(var(--bs-body-bg-rgb, 248, 249, 250), 0.85);
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
 }
 
 .app-header .navbar-brand {
@@ -61,8 +64,9 @@ a:focus {
 }
 
 .app-header .navbar-brand .brand-logo {
-    background: rgba(var(--bs-primary-rgb), 0.1);
+    background: rgba(var(--bs-primary-rgb), 0.12);
     color: var(--bs-primary);
+    box-shadow: inset 0 0 0 1px rgba(var(--bs-primary-rgb), 0.12);
 }
 
 .app-header .navbar-brand:hover,
@@ -87,6 +91,7 @@ a:focus {
     top: 0.35rem;
     right: 0.25rem;
     margin-left: 0 !important;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75);
 }
 
 .app-header .nav-link:hover,
@@ -164,7 +169,7 @@ button::-moz-focus-inner {
     width: var(--app-sidebar-width);
     background: var(--app-sidebar-bg-gradient);
     color: var(--app-sidebar-color);
-    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04);
+    box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.08);
 }
 
 .app-sidebar-content {
@@ -210,8 +215,8 @@ button::-moz-focus-inner {
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    border-radius: 0.75rem;
-    padding: 0.65rem 0.85rem;
+    border-radius: 0.85rem;
+    padding: 0.65rem 0.95rem;
     transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -241,7 +246,7 @@ button::-moz-focus-inner {
 
 .app-sidebar .nav-sidebar > .nav-item > .nav-treeview {
     margin-left: 2.25rem;
-    border-left: 1px dashed rgba(255, 255, 255, 0.1);
+    border-left: 1px dashed rgba(255, 255, 255, 0.12);
     padding-left: 1.25rem;
     gap: 0.35rem;
 }
@@ -254,13 +259,13 @@ button::-moz-focus-inner {
 .app-sidebar .nav-header {
     padding: 0.75rem 0.5rem;
     letter-spacing: 0.08em;
-    color: rgba(255, 255, 255, 0.5);
+    color: rgba(255, 255, 255, 0.55);
 }
 
 .app-sidebar .brand-logo {
     width: 2.75rem;
     height: 2.75rem;
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.12);
     color: #fff;
     font-size: 1.1rem;
 }
@@ -326,6 +331,7 @@ body.sidebar-open .app-sidebar-overlay {
 .app-content-header {
     padding: 1.5rem 0;
     background: rgba(var(--bs-primary-rgb), 0.03);
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
 }
 
 .app-content-header .breadcrumb {
@@ -354,30 +360,320 @@ body.sidebar-open .app-sidebar-overlay {
 }
 
 .card {
-    border: 0;
-    border-radius: 1rem;
+    border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    border-radius: 1.25rem;
     box-shadow: var(--app-card-shadow);
+    background: var(--bs-body-bg);
+    overflow: hidden;
 }
 
 .card-header {
-    border-bottom: 0;
-    background: rgba(var(--bs-primary-rgb), 0.05);
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    background: rgba(var(--bs-primary-rgb), 0.04);
     font-weight: 600;
+}
+
+.card-header .card-title {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+}
+
+.card-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .card-footer {
     background: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.04);
-    border-top: 0;
+    border-top: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+}
+
+.card-footer:last-child {
+    border-radius: 0 0 1.25rem 1.25rem;
+}
+
+.card-borderless {
+    border-color: transparent;
+    box-shadow: none;
+    background: transparent;
+}
+
+.card-borderless .card-header,
+.card-borderless .card-footer {
+    border-color: transparent;
+    background: transparent;
+}
+
+.box {
+    border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    border-radius: 1.25rem;
+    background: var(--bs-body-bg);
+    box-shadow: var(--app-card-shadow);
+    margin-bottom: 1.5rem;
+}
+
+.box-header {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    background: rgba(var(--bs-primary-rgb), 0.04);
+    border-top-left-radius: 1.25rem;
+    border-top-right-radius: 1.25rem;
+}
+
+.box-header .box-title {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0.02em;
+    font-weight: 600;
+}
+
+.box-body {
+    padding: 1.5rem;
+}
+
+.box-footer {
+    padding: 1.25rem 1.5rem;
+    border-top: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    background: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.04);
+    border-bottom-left-radius: 1.25rem;
+    border-bottom-right-radius: 1.25rem;
+}
+
+.box-tools {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-tabs-custom {
+    border-radius: 1.25rem;
+    box-shadow: var(--app-card-shadow);
+    background: var(--bs-body-bg);
+    border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    overflow: hidden;
+}
+
+.nav-tabs-custom > .nav-tabs {
+    margin: 0;
+    padding: 0.5rem 0.75rem 0;
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+}
+
+.nav-tabs-custom > .nav-tabs li {
+    margin: 0 0.25rem;
+}
+
+.nav-tabs-custom > .tab-content {
+    padding: 1.5rem;
+    background: var(--bs-body-bg);
+}
+
+.stat-card {
+    --stat-card-accent-rgb: var(--bs-primary-rgb);
+    position: relative;
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+    background: var(--bs-body-bg);
+    border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    box-shadow: var(--app-card-shadow);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 1.5rem 3rem rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.12);
+}
+
+.stat-card-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.stat-card-meta {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.stat-card-label {
+    letter-spacing: 0.08em;
+    color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.6);
+}
+
+.stat-card-value {
+    font-size: clamp(1.75rem, 1.4rem + 1vw, 2.5rem);
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--bs-body-color);
+}
+
+.stat-card-icon {
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 1rem;
+    display: grid;
+    place-items: center;
+    font-size: 1.5rem;
+    color: rgb(var(--stat-card-accent-rgb));
+    background: rgba(var(--stat-card-accent-rgb), 0.12);
+    box-shadow: inset 0 0 0 1px rgba(var(--stat-card-accent-rgb), 0.08),
+        0 0.75rem 1.5rem rgba(var(--stat-card-accent-rgb), 0.2);
+}
+
+.stat-card-footer {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px dashed rgba(var(--stat-card-accent-rgb), 0.3);
+}
+
+.stat-card-link {
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 700;
+    text-decoration: none;
+    color: rgb(var(--stat-card-accent-rgb));
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.stat-card-link:hover,
+.stat-card-link:focus {
+    color: rgb(var(--stat-card-accent-rgb));
+    opacity: 0.85;
+}
+
+.stat-card.bg-aqua {
+    --stat-card-accent-rgb: 14, 165, 233;
+}
+
+.stat-card.bg-green {
+    --stat-card-accent-rgb: 16, 185, 129;
+}
+
+.stat-card.bg-yellow {
+    --stat-card-accent-rgb: 245, 158, 11;
+}
+
+.stat-card.bg-red {
+    --stat-card-accent-rgb: 239, 68, 68;
+}
+
+.stat-card.bg-purple {
+    --stat-card-accent-rgb: 168, 85, 247;
+}
+
+.stat-card.bg-info {
+    --stat-card-accent-rgb: 14, 165, 233;
+}
+
+.stat-card.bg-primary {
+    --stat-card-accent-rgb: var(--bs-primary-rgb);
+}
+
+.stat-card.bg-gray {
+    --stat-card-accent-rgb: 148, 163, 184;
+}
+
+.stat-card.bg-black {
+    --stat-card-accent-rgb: 15, 23, 42;
+}
+
+.stat-card.bg-maroon {
+    --stat-card-accent-rgb: 190, 18, 60;
+}
+
+.stat-card.bg-teal {
+    --stat-card-accent-rgb: 20, 184, 166;
+}
+
+.stat-card.bg-navy {
+    --stat-card-accent-rgb: 30, 64, 175;
+}
+
+.stat-card.bg-success {
+    --stat-card-accent-rgb: var(--bs-success-rgb);
+}
+
+.stat-card.bg-warning {
+    --stat-card-accent-rgb: var(--bs-warning-rgb);
+}
+
+.stat-card.bg-danger {
+    --stat-card-accent-rgb: var(--bs-danger-rgb);
+}
+
+.nav-tabs {
+    border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.08);
+    gap: 0.25rem;
+}
+
+.nav-tabs .nav-link {
+    border: 0;
+    border-bottom: 2px solid transparent;
+    border-radius: 0.75rem 0.75rem 0 0;
+    color: var(--bs-secondary-color);
+    font-weight: 600;
+    padding: 0.75rem 1.25rem;
+    transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.nav-tabs .nav-link:hover,
+.nav-tabs .nav-link:focus {
+    color: var(--bs-primary);
+    border-bottom-color: rgba(var(--bs-primary-rgb), 0.45);
+    background-color: rgba(var(--bs-primary-rgb), 0.08);
+}
+
+.nav-tabs .nav-link.active,
+.nav-tabs .nav-item.show .nav-link {
+    color: var(--bs-primary);
+    border-bottom-color: var(--bs-primary);
+    background-color: rgba(var(--bs-primary-rgb), 0.12);
+}
+
+.table {
+    border-collapse: separate;
+    border-spacing: 0;
+    overflow: hidden;
 }
 
 .table thead th {
-    background: rgba(var(--bs-primary-rgb), 0.08);
+    background: rgba(var(--bs-primary-rgb), 0.1);
     border-bottom: 0;
     font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.7);
+}
+
+.table thead th:first-child {
+    border-top-left-radius: 0.75rem;
+}
+
+.table thead th:last-child {
+    border-top-right-radius: 0.75rem;
+}
+
+.table tbody tr:last-child td:first-child {
+    border-bottom-left-radius: 0.75rem;
+}
+
+.table tbody tr:last-child td:last-child {
+    border-bottom-right-radius: 0.75rem;
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) > * {
     background-color: rgba(var(--bs-primary-rgb), 0.03);
+}
+
+.table-hover tbody tr:hover > * {
+    background-color: rgba(var(--bs-primary-rgb), 0.08);
 }
 
 .alert {
@@ -386,15 +682,35 @@ body.sidebar-open .app-sidebar-overlay {
     box-shadow: var(--app-card-shadow);
 }
 
-.pagination .page-link {
-    border-radius: 0.65rem;
-    border: 0;
-    margin: 0 0.125rem;
-    box-shadow: none;
+.pagination {
+    gap: 0.35rem;
 }
 
-.pagination .page-link:hover {
-    background: rgba(var(--bs-primary-rgb), 0.1);
+.pagination .page-link {
+    border-radius: 0.75rem;
+    border: 0;
+    margin: 0;
+    padding: 0.5rem 0.9rem;
+    font-weight: 600;
+    color: var(--bs-secondary-color);
+    background-color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.05);
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.pagination .page-link:hover,
+.pagination .page-link:focus {
+    background: rgba(var(--bs-primary-rgb), 0.12);
+    color: var(--bs-primary);
+}
+
+.pagination .page-item.active .page-link {
+    background-color: var(--bs-primary);
+    color: #fff;
+}
+
+.pagination .page-item.disabled .page-link {
+    background-color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.05);
+    color: rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.35);
 }
 
 .form-control,
@@ -425,6 +741,29 @@ body.sidebar-open .app-sidebar-overlay {
 .offcanvas {
     border-radius: 1rem 1rem 0 0;
     box-shadow: var(--app-card-shadow);
+}
+
+.btn-default {
+    color: var(--bs-secondary-color);
+    background-color: transparent;
+    border: 1px solid rgba(var(--bs-body-color-rgb, 33, 37, 41), 0.15);
+    border-radius: 0.75rem;
+    padding: 0.5rem 1rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-default:hover,
+.btn-default:focus {
+    color: var(--bs-primary);
+    background-color: rgba(var(--bs-primary-rgb), 0.08);
+    border-color: rgba(var(--bs-primary-rgb), 0.45);
+    box-shadow: 0 0.5rem 1.5rem rgba(var(--bs-primary-rgb), 0.12);
+}
+
+.btn-default:disabled,
+.btn-default.disabled {
+    opacity: 0.6;
+    box-shadow: none;
 }
 
 .app-footer {

--- a/backend/widgets/box/SmallBox.php
+++ b/backend/widgets/box/SmallBox.php
@@ -78,26 +78,40 @@ class SmallBox extends Widget
      */
     public function renderContent()
     {
-        $str = '';
-        $str .= Html::beginTag('div', ['id' => $this->id, 'class' => 'small-box ' . $this->style]) . PHP_EOL;
-        $str .= Html::beginTag('div', ['class' => 'inner']) . PHP_EOL;
-        $str .= Html::tag('h3', $this->header) . PHP_EOL;
-        $str .= Html::tag('p', $this->content) . PHP_EOL;
-        $str .= Html::endTag('div') . PHP_EOL;
-        $str .= Html::beginTag('div', ['icon']) . PHP_EOL;
-        $str .= Html::tag('i', '', ['class' => 'icon ' . $this->icon]) . PHP_EOL;
-        $str .= Html::endTag('div') . PHP_EOL;
+        $options = [
+            'id' => $this->id,
+            'class' => trim('stat-card ' . $this->style),
+        ];
+
+        $content = Html::beginTag('div', ['class' => 'stat-card-body']) . PHP_EOL;
+        $content .= Html::beginTag('div', ['class' => 'stat-card-meta']) . PHP_EOL;
+        $content .= Html::tag('div', $this->content, ['class' => 'stat-card-label text-uppercase small fw-semibold']) . PHP_EOL;
+        $content .= Html::tag('div', $this->header, ['class' => 'stat-card-value']) . PHP_EOL;
+        $content .= Html::endTag('div') . PHP_EOL;
+        $content .= Html::tag('span', Html::tag('i', '', ['class' => 'icon ' . $this->icon]), ['class' => 'stat-card-icon']) . PHP_EOL;
+        $content .= Html::endTag('div') . PHP_EOL;
+
+        $footer = '';
         if (is_array($this->link)) {
             if (!empty($this->link['label']) && !empty($this->link['url'])) {
-                $str .= Html::a($this->link['label'], $this->link['url'], [
-                        'class' => 'small-box-footer'
-                    ]) . PHP_EOL;
+                $label = Html::encode($this->link['label']) . ' <i class="fas fa-arrow-right ms-2"></i>';
+                $footer = Html::tag(
+                    'div',
+                    Html::a(
+                        $label,
+                        $this->link['url'],
+                        [
+                            'class' => 'stat-card-link',
+                        ]
+                    ),
+                    ['class' => 'stat-card-footer']
+                );
             }
-        } elseif (!is_null($this->link)) {
-            $str .= Html::tag('div', $this->link, ['class' => 'small-box-footer']);
+        } elseif ($this->link !== null) {
+            $footer = Html::tag('div', $this->link, ['class' => 'stat-card-footer']);
         }
-        $str .= Html::endTag('div') . PHP_EOL;
-        return $str;
+
+        return Html::tag('div', $content . $footer, $options) . PHP_EOL;
     }
 
     /**

--- a/backend/widgets/chart/flot/Chart.php
+++ b/backend/widgets/chart/flot/Chart.php
@@ -142,24 +142,44 @@ class Chart extends Widget
                 if (realtime_{$this->id} === '{$on}') {
                     update_{$this->id}();
                 }
-                
-                // REALTIME TOGGLE                
-                btnRealtime_{$this->id}.click(function () {                
-                    btnRealtime_{$this->id}.addClass('btn-default');
-                    $(this).removeClass('btn-default');                
+
+                btnRealtime_{$this->id}
+                    .removeClass('btn-outline-success btn-outline-danger active')
+                    .addClass('btn-outline-secondary');
+
+                btnRealtime_{$this->id}.each(function () {
+                    if ($(this).data('toggle') === realtime_{$this->id}) {
+                        const stateClass = (realtime_{$this->id} === '{$on}') ? 'btn-outline-success' : 'btn-outline-danger';
+                        $(this)
+                            .removeClass('btn-outline-secondary')
+                            .addClass(stateClass)
+                            .addClass('active');
+                    }
+                });
+
+                // REALTIME TOGGLE
+                btnRealtime_{$this->id}.click(function () {
+                    btnRealtime_{$this->id}
+                        .addClass('btn-outline-secondary')
+                        .removeClass('btn-outline-success btn-outline-danger active');
+                    $(this).removeClass('btn-outline-secondary').addClass('active');
                     if ($(this).data('toggle') === '{$on}') {
-                        if(realtime_{$this->id} !== '{$on}') {
+                        if (realtime_{$this->id} !== '{$on}') {
                             realtime_{$this->id} = '{$on}';
-                            btnRealtime_{$this->id}.removeClass('btn-danger');                        
-                            $(this).addClass('btn-success');
+                            btnRealtime_{$this->id}.removeClass('btn-outline-danger');
+                            $(this).addClass('btn-outline-success');
                             update_{$this->id}();
-                        }                                    
+                        } else {
+                            $(this).addClass('btn-outline-success');
+                        }
                     } else {
-                        if(realtime_{$this->id} !== '{$off}') {
-                            realtime_{$this->id} = '{$off}'; 
-                            btnRealtime_{$this->id}.removeClass('btn-success');                        
-                            $(this).addClass('btn-danger');
+                        if (realtime_{$this->id} !== '{$off}') {
+                            realtime_{$this->id} = '{$off}';
+                            btnRealtime_{$this->id}.removeClass('btn-outline-success');
+                            $(this).addClass('btn-outline-danger');
                             update_{$this->id}();
+                        } else {
+                            $(this).addClass('btn-outline-danger');
                         }
                     }
                 });

--- a/modules/main/views/backend/default/index.php
+++ b/modules/main/views/backend/default/index.php
@@ -15,9 +15,9 @@ $this->title = Module::translate('module', 'Home');
 $this->params['title']['small'] = Module::translate('module', 'Dashboard');
 ?>
 
-<section class="content main-backend-default-index">
-    <div class="row">
-        <div class="col-lg-3 col-xs-6">
+<div class="main-backend-default-index">
+    <div class="row g-4 mb-4">
+        <div class="col-12 col-sm-6 col-xl-3">
             <?= SmallBox::widget([
                 'status' => true,
                 'style' => SmallBox::BG_AQUA,
@@ -25,15 +25,12 @@ $this->params['title']['small'] = Module::translate('module', 'Dashboard');
                 'header' => 150,
                 'content' => 'New Orders',
                 'link' => [
-                    'label' => Yii::t(
-                        'app',
-                        'More info'
-                    ) . ' <i class="fa fa-arrow-circle-right"></i>',
-                    'url' => ['#']
-                ]
+                    'label' => Yii::t('app', 'More info'),
+                    'url' => ['#'],
+                ],
             ]) ?>
         </div>
-        <div class="col-lg-3 col-xs-6">
+        <div class="col-12 col-sm-6 col-xl-3">
             <?= SmallBox::widget([
                 'status' => true,
                 'style' => SmallBox::BG_GREEN,
@@ -41,15 +38,12 @@ $this->params['title']['small'] = Module::translate('module', 'Dashboard');
                 'header' => '53<sup style="font-size: 20px">%</sup>',
                 'content' => 'Bounce Rate',
                 'link' => [
-                    'label' => Yii::t(
-                        'app',
-                        'More info'
-                    ) . ' <i class="fa fa-arrow-circle-right"></i>',
-                    'url' => ['#']
-                ]
+                    'label' => Yii::t('app', 'More info'),
+                    'url' => ['#'],
+                ],
             ]) ?>
         </div>
-        <div class="col-lg-3 col-xs-6">
+        <div class="col-12 col-sm-6 col-xl-3">
             <?= SmallBox::widget([
                 'status' => true,
                 'style' => SmallBox::BG_YELLOW,
@@ -57,15 +51,12 @@ $this->params['title']['small'] = Module::translate('module', 'Dashboard');
                 'header' => $usersCount,
                 'content' => Yii::t('app', 'User Registrations'),
                 'link' => [
-                    'label' => Yii::t(
-                        'app',
-                        'More info'
-                    ) . ' <i class="fa fa-arrow-circle-right"></i>',
-                    'url' => ['/users/default/index']
-                ]
+                    'label' => Yii::t('app', 'More info'),
+                    'url' => ['/users/default/index'],
+                ],
             ]) ?>
         </div>
-        <div class="col-lg-3 col-xs-6">
+        <div class="col-12 col-sm-6 col-xl-3">
             <?= SmallBox::widget([
                 'status' => true,
                 'style' => SmallBox::BG_RED,
@@ -73,387 +64,433 @@ $this->params['title']['small'] = Module::translate('module', 'Dashboard');
                 'header' => 65,
                 'content' => 'Unique Visitors',
                 'link' => [
-                    'label' => Yii::t(
-                        'app',
-                        'More info'
-                    ) . ' <i class="fa fa-arrow-circle-right"></i>',
-                    'url' => ['#']
-                ]
+                    'label' => Yii::t('app', 'More info'),
+                    'url' => ['#'],
+                ],
             ]) ?>
         </div>
     </div>
-    <div class="row">
-        <section class="col-lg-7 connectedSortable">
-            <div class="nav-tabs-custom">
-                <ul class="nav nav-tabs float-end">
-                    <li class="active"><a href="#area-chart" data-toggle="tab">Area</a></li>
-                    <li><a href="#doughnut-chart" data-toggle="tab">Doughnut</a></li>
-                    <li><a href="#pie-chart" data-toggle="tab">Pie</a></li>
-                    <li><a href="#line-chart" data-toggle="tab">Line</a></li>
-                    <li><a href="#bar-chart" data-toggle="tab">Bar</a></li>
-                    <li><a href="#radar-chart" data-toggle="tab">Radar</a></li>
-                    <li><a href="#bubble-chart" data-toggle="tab">Bubble</a></li>
-                    <li class="float-start header"><i class="fa fa-bar-chart"></i> Charts</li>
-                </ul>
 
-                <div class="tab-content no-padding">
-                    <div id="area-chart" class="chart tab-pane active">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_LINE,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Area Chart'
-                                ],
-                                'scales' => [
-                                    'xAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Month'
-                                            ]
-                                        ]
-                                    ],
-                                    'yAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Value'
-                                            ]
-                                        ]
-                                    ],
-                                ],
-                            ],
-                            'clientData' => [
-                                'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'hidden' => false,
-                                        'backgroundColor' => 'rgb(160, 208, 224, 0.5)',
-                                        'borderColor' => 'rgb(160, 208, 224, 0.7)',
-                                        'data' => [65, 59, 80, 81, 56, 55, 40]
-                                    ],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'hidden' => false,
-                                        'backgroundColor' => 'rgb(60, 141, 188, 0.5)',
-                                        'borderColor' => 'rgb(60, 141, 188, 0.7)',
-                                        'data' => [28, 48, 40, 19, 86, 27, 90]
-                                    ]
-                                ],
-                            ]
-                        ]) ?>
+    <div class="row g-4">
+        <div class="col-12 col-xl-7 connectedSortable">
+            <div class="card shadow-sm h-100">
+                <div class="card-header border-0 pb-0">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                        <h5 class="card-title mb-0">
+                            <i class="fas fa-chart-line text-primary me-2"></i>
+                            <?= Yii::t('app', 'Sales dynamics') ?>
+                        </h5>
+                        <span class="text-body-secondary small">
+                            <?= Yii::t('app', 'Switch between the most requested chart types') ?>
+                        </span>
                     </div>
-                    <div id="doughnut-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_DOUGHNUT,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'legend' => [
-                                    'position' => 'top'
-                                ],
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Doughnut Chart',
-                                ],
-                                'animation' => [
-                                    'animateScale' => true,
-                                    'animateRotate' => true,
-                                ],
-                            ],
-                            'clientData' => [
-                                'labels' => ['Download Sales', 'In-Store Sales', 'Mail-Order Sales'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'backgroundColor' => [
-                                            '#3c8dbc',
-                                            '#f56954',
-                                            '#00a65a',
-                                        ],
-                                        'data' => [12, 30, 20]
-                                    ],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'backgroundColor' => [
-                                            '#3c8dbc',
-                                            '#f56954',
-                                            '#00a65a',
-                                        ],
-                                        'data' => [20, 18, 50]
-                                    ],
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
-                    <div id="pie-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_PIE,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'legend' => [
-                                    'position' => 'top'
-                                ],
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Doughnut Chart',
-                                ],
-                                'animation' => [
-                                    'animateScale' => true,
-                                    'animateRotate' => true,
-                                ],
-                            ],
-                            'clientData' => [
-                                'labels' => ['Download Sales', 'In-Store Sales', 'Mail-Order Sales'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'backgroundColor' => [
-                                            '#3c8dbc',
-                                            '#f56954',
-                                            '#00a65a',
-                                        ],
-                                        'data' => [12, 30, 20]
-                                    ],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'backgroundColor' => [
-                                            '#3c8dbc',
-                                            '#f56954',
-                                            '#00a65a',
-                                        ],
-                                        'data' => [20, 18, 50]
-                                    ],
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
-                    <div id="line-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_LINE,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Line Chart'
-                                ],
-                                'scales' => [
-                                    'xAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Month'
-                                            ]
-                                        ]
-                                    ],
-                                    'yAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Value'
-                                            ]
-                                        ]
-                                    ],
-                                ],
-                            ],
-                            'clientData' => [
-                                'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'hidden' => false,
-                                        'fill' => false,
-                                        'backgroundColor' => 'rgb(160, 208, 224, 0.5)',
-                                        'borderColor' => 'rgb(160, 208, 224, 0.8)',
-                                        'data' => [65, 59, 80, 81, 56, 55, 40]],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'hidden' => false,
-                                        'fill' => false,
-                                        'backgroundColor' => 'rgb(60, 141, 188, 0.9)',
-                                        'borderColor' => 'rgb(60, 141, 188, 0.8)',
-                                        'data' => [28, 48, 40, 19, 86, 27, 90]
-                                    ]
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
-                    <div id="bar-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_BAR,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Bar Chart'
-                                ],
-                                'scales' => [
-                                    'xAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Month'
-                                            ]
-                                        ]
-                                    ],
-                                    'yAxes' => [
-                                        [
-                                            'display' => true,
-                                            'scaleLabel' => [
-                                                'display' => true,
-                                                'labelString' => 'Value'
-                                            ]
-                                        ]
-                                    ],
-                                ],
-                            ],
-                            'clientData' => [
-                                'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'backgroundColor' => 'rgb(160, 208, 224, 0.5)',
-                                        'data' => [65, 59, 80, 81, 56, 55, 40]],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'backgroundColor' => 'rgb(60, 141, 188, 0.9)',
-                                        'data' => [28, 48, 40, 19, 86, 27, 90]
-                                    ]
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
-                    <div id="radar-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_RADAR,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Radar Chart'
-                                ]
-                            ],
-                            'clientData' => [
-                                'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'backgroundColor' => 'rgb(160, 208, 224, 0.5)',
-                                        'data' => [65, 59, 80, 81, 56, 55, 40]],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'backgroundColor' => 'rgb(60, 141, 188, 0.9)',
-                                        'data' => [28, 48, 40, 19, 86, 27, 90]
-                                    ]
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
-                    <div id="bubble-chart" class="chart tab-pane">
-                        <?= Chart::widget([
-                            'status' => true,
-                            'type' => Chart::TYPE_BUBBLE,
-                            'clientOptions' => [
-                                'responsive' => true,
-                                'title' => [
-                                    'display' => true,
-                                    'text' => 'Chart.js Bubble Chart',
-                                ],
-                                'tooltips' => [
-                                    'mode' => 'point',
-                                ],
-                            ],
-                            'clientData' => [
-                                'animation' => [
-                                    'duration' => 10000
-                                ],
-                                'datasets' => [
-                                    [
-                                        'label' => 'Electronics',
-                                        'backgroundColor' => 'rgb(255, 0, 0, 0.5)',
-                                        'borderColor' => 'rgb(255, 0, 0, 0.9)',
-                                        'borderWidth' => 1,
-                                        'data' => [
-                                            ['x' => 30, 'y' => 40, 'r' => 20],
-                                            ['x' => 18, 'y' => 12, 'r' => 10],
-                                            ['x' => 60, 'y' => -35, 'r' => 5],
-                                            ['x' => 48, 'y' => 40, 'r' => 10]
-                                        ]
-                                    ],
-                                    [
-                                        'label' => 'Digital Goods',
-                                        'backgroundColor' => 'rgb(0, 255, 0, 0.5)',
-                                        'borderColor' => 'rgb(0, 255, 0, 0.9)',
-                                        'borderWidth' => 1,
-                                        'data' => [
-                                            ['x' => 10, 'y' => 25, 'r' => 17],
-                                            ['x' => 25, 'y' => -10, 'r' => 25],
-                                            ['x' => 40, 'y' => 55, 'r' => 30],
-                                            ['x' => 35, 'y' => 20, 'r' => 16],
-                                        ]
-                                    ],
-                                ],
-                            ]
-                        ]) ?>
-                    </div>
+                    <ul class="nav nav-tabs card-header-tabs mt-4" id="dashboard-chart-tabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link active" id="area-chart-tab" data-bs-toggle="tab" href="#area-chart" role="tab" aria-controls="area-chart" aria-selected="true">
+                                <?= Yii::t('app', 'Area') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="doughnut-chart-tab" data-bs-toggle="tab" href="#doughnut-chart" role="tab" aria-controls="doughnut-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Doughnut') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="pie-chart-tab" data-bs-toggle="tab" href="#pie-chart" role="tab" aria-controls="pie-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Pie') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="line-chart-tab" data-bs-toggle="tab" href="#line-chart" role="tab" aria-controls="line-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Line') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="bar-chart-tab" data-bs-toggle="tab" href="#bar-chart" role="tab" aria-controls="bar-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Bar') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="radar-chart-tab" data-bs-toggle="tab" href="#radar-chart" role="tab" aria-controls="radar-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Radar') ?>
+                            </a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" id="bubble-chart-tab" data-bs-toggle="tab" href="#bubble-chart" role="tab" aria-controls="bubble-chart" aria-selected="false">
+                                <?= Yii::t('app', 'Bubble') ?>
+                            </a>
+                        </li>
+                    </ul>
                 </div>
-            </div>
-        </section>
-
-        <section class="col-lg-5 connectedSortable">
-            <div class="box box-primary">
-                <div class="box-header">
-                    <i class="fa fa-bar-chart-o"></i>
-                    <h3 class="box-title">Flot Line Ajax Chart</h3>
-                    <div class="box-tools float-end">
-                        Real time
-                        <div class="btn-group" id="realtime" data-toggle="btn-toggle">
-                            <button type="button" class="btn btn-default btn-xs" data-toggle="on">On</button>
-                            <button type="button" class="btn btn-danger btn-xs" data-toggle="off">Off</button>
+                <div class="card-body">
+                    <div class="tab-content" id="dashboard-chart-tabs-content">
+                        <div class="tab-pane fade show active" id="area-chart" role="tabpanel" aria-labelledby="area-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_LINE,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Area Chart',
+                                    ],
+                                    'scales' => [
+                                        'xAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Month',
+                                                ],
+                                            ],
+                                        ],
+                                        'yAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Value',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'hidden' => false,
+                                            'backgroundColor' => 'rgba(160, 208, 224, 0.5)',
+                                            'borderColor' => 'rgba(160, 208, 224, 0.7)',
+                                            'data' => [65, 59, 80, 81, 56, 55, 40],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'hidden' => false,
+                                            'backgroundColor' => 'rgba(60, 141, 188, 0.5)',
+                                            'borderColor' => 'rgba(60, 141, 188, 0.7)',
+                                            'data' => [28, 48, 40, 19, 86, 27, 90],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="doughnut-chart" role="tabpanel" aria-labelledby="doughnut-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_DOUGHNUT,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'legend' => [
+                                        'position' => 'top',
+                                    ],
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Doughnut Chart',
+                                    ],
+                                    'animation' => [
+                                        'animateScale' => true,
+                                        'animateRotate' => true,
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['Download Sales', 'In-Store Sales', 'Mail-Order Sales'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'backgroundColor' => [
+                                                '#3c8dbc',
+                                                '#f56954',
+                                                '#00a65a',
+                                            ],
+                                            'data' => [12, 30, 20],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'backgroundColor' => [
+                                                '#3c8dbc',
+                                                '#f56954',
+                                                '#00a65a',
+                                            ],
+                                            'data' => [20, 18, 50],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="pie-chart" role="tabpanel" aria-labelledby="pie-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_PIE,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'legend' => [
+                                        'position' => 'top',
+                                    ],
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Pie Chart',
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['Download Sales', 'In-Store Sales', 'Mail-Order Sales'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'backgroundColor' => [
+                                                '#3c8dbc',
+                                                '#f56954',
+                                                '#00a65a',
+                                            ],
+                                            'data' => [12, 30, 20],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'backgroundColor' => [
+                                                '#3c8dbc',
+                                                '#f56954',
+                                                '#00a65a',
+                                            ],
+                                            'data' => [20, 18, 50],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="line-chart" role="tabpanel" aria-labelledby="line-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_LINE,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Line Chart',
+                                    ],
+                                    'scales' => [
+                                        'xAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Month',
+                                                ],
+                                            ],
+                                        ],
+                                        'yAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Value',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'hidden' => false,
+                                            'fill' => false,
+                                            'backgroundColor' => 'rgba(160, 208, 224, 0.5)',
+                                            'borderColor' => 'rgba(160, 208, 224, 0.8)',
+                                            'data' => [65, 59, 80, 81, 56, 55, 40],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'hidden' => false,
+                                            'fill' => false,
+                                            'backgroundColor' => 'rgba(60, 141, 188, 0.9)',
+                                            'borderColor' => 'rgba(60, 141, 188, 0.8)',
+                                            'data' => [28, 48, 40, 19, 86, 27, 90],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="bar-chart" role="tabpanel" aria-labelledby="bar-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_BAR,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Bar Chart',
+                                    ],
+                                    'scales' => [
+                                        'xAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Month',
+                                                ],
+                                            ],
+                                        ],
+                                        'yAxes' => [
+                                            [
+                                                'display' => true,
+                                                'scaleLabel' => [
+                                                    'display' => true,
+                                                    'labelString' => 'Value',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'backgroundColor' => 'rgba(160, 208, 224, 0.5)',
+                                            'data' => [65, 59, 80, 81, 56, 55, 40],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'backgroundColor' => 'rgba(60, 141, 188, 0.9)',
+                                            'data' => [28, 48, 40, 19, 86, 27, 90],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="radar-chart" role="tabpanel" aria-labelledby="radar-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_RADAR,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Radar Chart',
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'labels' => ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'backgroundColor' => 'rgba(160, 208, 224, 0.5)',
+                                            'data' => [65, 59, 80, 81, 56, 55, 40],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'backgroundColor' => 'rgba(60, 141, 188, 0.9)',
+                                            'data' => [28, 48, 40, 19, 86, 27, 90],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
+                        </div>
+                        <div class="tab-pane fade" id="bubble-chart" role="tabpanel" aria-labelledby="bubble-chart-tab">
+                            <?= Chart::widget([
+                                'status' => true,
+                                'type' => Chart::TYPE_BUBBLE,
+                                'clientOptions' => [
+                                    'responsive' => true,
+                                    'title' => [
+                                        'display' => true,
+                                        'text' => 'Chart.js Bubble Chart',
+                                    ],
+                                    'tooltips' => [
+                                        'mode' => 'point',
+                                    ],
+                                ],
+                                'clientData' => [
+                                    'animation' => [
+                                        'duration' => 10000,
+                                    ],
+                                    'datasets' => [
+                                        [
+                                            'label' => 'Electronics',
+                                            'backgroundColor' => 'rgba(255, 0, 0, 0.5)',
+                                            'borderColor' => 'rgba(255, 0, 0, 0.9)',
+                                            'borderWidth' => 1,
+                                            'data' => [
+                                                ['x' => 30, 'y' => 40, 'r' => 20],
+                                                ['x' => 18, 'y' => 12, 'r' => 10],
+                                                ['x' => 60, 'y' => -35, 'r' => 5],
+                                                ['x' => 48, 'y' => 40, 'r' => 10],
+                                            ],
+                                        ],
+                                        [
+                                            'label' => 'Digital Goods',
+                                            'backgroundColor' => 'rgba(0, 255, 0, 0.5)',
+                                            'borderColor' => 'rgba(0, 255, 0, 0.9)',
+                                            'borderWidth' => 1,
+                                            'data' => [
+                                                ['x' => 10, 'y' => 25, 'r' => 17],
+                                                ['x' => 25, 'y' => -10, 'r' => 25],
+                                                ['x' => 40, 'y' => 55, 'r' => 30],
+                                                ['x' => 35, 'y' => 20, 'r' => 16],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ]) ?>
                         </div>
                     </div>
                 </div>
-                <div class="box-body">
+            </div>
+        </div>
+
+        <div class="col-12 col-xl-5 connectedSortable">
+            <div class="card shadow-sm h-100">
+                <div class="card-header border-0 pb-0">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                        <h5 class="card-title mb-0">
+                            <i class="fas fa-wave-square text-primary me-2"></i>
+                            <?= Yii::t('app', 'Realtime traffic') ?>
+                        </h5>
+                        <div class="card-toolbar">
+                            <span class="text-uppercase small fw-semibold text-body-secondary">
+                                <?= Yii::t('app', 'Realtime') ?>
+                            </span>
+                            <div class="btn-group btn-group-sm" id="realtime" role="group" aria-label="<?= Yii::t('app', 'Realtime toggle') ?>">
+                                <button type="button" class="btn btn-outline-secondary" data-toggle="on">
+                                    <?= Yii::t('app', 'On') ?>
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary active" data-toggle="off">
+                                    <?= Yii::t('app', 'Off') ?>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body">
                     <?= FlotChart::widget([
                         'status' => true,
                         'containerOptions' => [
-                            'style' => 'height:300px;'
+                            'style' => 'height:300px;',
                         ],
                         'realtime' => [
                             'on' => true,
                             'dataUrl' => Url::to(['/main/default/get-demo-data']),
                             'btnGroupId' => 'realtime',
                             'btnDefault' => FlotChart::REALTIME_OFF,
-                            'updateInterval' => 1000
+                            'updateInterval' => 1000,
                         ],
                         'clientData' => [
-                            backend\components\Demo::getRandomData()
+                            backend\components\Demo::getRandomData(),
                         ],
                         'clientOptions' => [
                             'grid' => [
                                 'borderColor' => '#f3f3f3',
                                 'borderWidth' => 1,
-                                'tickColor' => '#f3f3f3'
+                                'tickColor' => '#f3f3f3',
                             ],
                             'series' => [
-                                'shadowSize' => 0, // Drawing is faster without shadows
+                                'shadowSize' => 0,
                                 'color' => '#3c8dbc',
                             ],
                             'lines' => [
-                                'fill' => false, //Converts the line chart to area chart
+                                'fill' => false,
                                 'color' => '#3c8dbc',
                             ],
                             'yaxis' => [
@@ -463,120 +500,114 @@ $this->params['title']['small'] = Module::translate('module', 'Dashboard');
                             ],
                             'xaxis' => [
                                 'show' => true,
-                            ]
+                            ],
                         ],
                     ]) ?>
                 </div>
             </div>
-        </section>
+        </div>
 
-        <section class="col-lg-5 connectedSortable">
-            <div class="box box-solid bg-light-blue-gradient">
-                <div class="box-header">
-                    <div class="box-tools float-end">
-                        <!--<button type="button"
-                         class="btn btn-primary btn-sm daterange float-end"
-                         data-toggle="tooltip"
-                                title="Date range">
-                            <i class="fa fa-calendar"></i></button>-->
-                        <button type="button" class="btn btn-primary btn-sm float-end" data-widget="collapse"
-                                data-toggle="tooltip" title="Collapse" style="margin-right: 5px;">
-                            <i class="fa fa-minus"></i>
-                        </button>
+        <div class="col-12 col-xl-5 connectedSortable">
+            <div class="card shadow-sm h-100 border-0 overflow-hidden text-white" style="background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 45%, #2563eb 70%, #22d3ee 100%);">
+                <div class="card-header border-0 bg-transparent">
+                    <div class="d-flex flex-wrap align-items-center justify-content-between">
+                        <h5 class="card-title mb-0 text-white">
+                            <i class="fas fa-earth-americas me-2"></i>
+                            <?= Yii::t('app', 'Visitors map') ?>
+                        </h5>
+                        <span class="text-white-50 small">
+                            <?= Yii::t('app', 'Live audience overview') ?>
+                        </span>
                     </div>
-                    <i class="fa fa-map-marker"></i>
-                    <h3 class="box-title">Visitors</h3>
                 </div>
-                <div class="box-body">
+                <div class="card-body bg-transparent">
                     <?= Map::widget([
                         'status' => true,
                         'containerOptions' => [
-                            'style' => 'height: 250px; width:100%;'
+                            'style' => 'height: 250px; width:100%;',
                         ],
                         'maps' => [
                             'world_mill_en' => 'world-mill-en',
-                            'world_mill' => 'world-mill'
+                            'world_mill' => 'world-mill',
                         ],
                         'clientOptions' => [
                             'map' => 'world_mill_en',
                             'backgroundColor' => 'transparent',
                             'regionStyle' => [
                                 'initial' => [
-                                    'fill' => '#e4e4e4',
+                                    'fill' => 'rgba(255, 255, 255, 0.12)',
                                     'fill-opacity' => 1,
                                     'stroke' => 'none',
                                     'stroke-width' => 0,
-                                    'stroke-opacity' => 1
-                                ]
+                                    'stroke-opacity' => 1,
+                                ],
                             ],
                             'series' => [
                                 'regions' => [
                                     [
                                         'values' => backend\components\Demo::getVisitorsData(),
-                                        'scale' => ['#92c1dc', '#ebf4f9'],
+                                        'scale' => ['#a5f3fc', '#f8fafc'],
                                         'normalizeFunction' => 'polynomial',
-                                    ]
-                                ]
+                                    ],
+                                ],
                             ],
-                            'onRegionTipShow' => new yii\web\JsExpression("
-                                function (e, el, code) {
-                                    let regions = $(this).data().mapObject.params.series.regions,
-                                        visitorsData = regions[0].values;
-                                    if (typeof visitorsData[code] !== 'undefined') {
-                                        el.html(el.html() + ': ' + visitorsData[code] + ' new visitors');
-                                    }
+                            'onRegionTipShow' => new yii\web\JsExpression("function (e, el, code) {
+                                let regions = $(this).data().mapObject.params.series.regions,
+                                    visitorsData = regions[0].values;
+                                if (typeof visitorsData[code] !== 'undefined') {
+                                    el.html(el.html() + ': ' + visitorsData[code] + ' new visitors');
                                 }
-                            ")
-                        ]
+                            }"),
+                        ],
                     ]) ?>
                 </div>
-                <div class="box-footer no-border">
-                    <div class="row">
-                        <div class="col-xs-4 text-center" style="border-right: 1px solid #f4f4f4">
+                <div class="card-footer bg-transparent border-0 pt-0">
+                    <div class="row g-0 text-center text-white-75">
+                        <div class="col-12 col-md-4 py-3 border-end border-white border-opacity-25">
                             <?= SparklineChart::widget([
                                 'status' => true,
                                 'clientData' => [1000, 1200, 920, 927, 931, 1027, 819, 930, 1021],
                                 'clientOptions' => [
                                     'type' => 'line',
-                                    'lineColor' => '#92c1dc',
-                                    'fillColor' => '#ebf4f9',
+                                    'lineColor' => '#ffffff',
+                                    'fillColor' => 'rgba(255, 255, 255, 0.25)',
                                     'height' => '50',
-                                    'width' => '80'
+                                    'width' => '80',
                                 ],
                             ]) ?>
-                            <div class="knob-label">Visitors</div>
+                            <div class="fw-semibold text-white mt-2">Visitors</div>
                         </div>
-                        <div class="col-xs-4 text-center" style="border-right: 1px solid #f4f4f4">
+                        <div class="col-12 col-md-4 py-3 border-end border-white border-opacity-25">
                             <?= SparklineChart::widget([
                                 'status' => true,
                                 'clientData' => [515, 519, 520, 522, 652, 810, 370, 627, 319, 630, 921],
                                 'clientOptions' => [
                                     'type' => 'line',
-                                    'lineColor' => '#92c1dc',
-                                    'fillColor' => '#ebf4f9',
+                                    'lineColor' => '#ffffff',
+                                    'fillColor' => 'rgba(255, 255, 255, 0.25)',
                                     'height' => '50',
-                                    'width' => '80'
+                                    'width' => '80',
                                 ],
                             ]) ?>
-                            <div class="knob-label">Online</div>
+                            <div class="fw-semibold text-white mt-2">Online</div>
                         </div>
-                        <div class="col-xs-4 text-center">
+                        <div class="col-12 col-md-4 py-3">
                             <?= SparklineChart::widget([
                                 'status' => true,
                                 'clientData' => [15, 19, 20, 22, 33, 27, 31, 27, 19, 30, 21],
                                 'clientOptions' => [
                                     'type' => 'line',
-                                    'lineColor' => '#92c1dc',
-                                    'fillColor' => '#ebf4f9',
+                                    'lineColor' => '#ffffff',
+                                    'fillColor' => 'rgba(255, 255, 255, 0.25)',
                                     'height' => '50',
-                                    'width' => '80'
+                                    'width' => '80',
                                 ],
                             ]) ?>
-                            <div class="knob-label">Exists</div>
+                            <div class="fw-semibold text-white mt-2">Exits</div>
                         </div>
                     </div>
                 </div>
             </div>
-        </section>
+        </div>
     </div>
-</section>
+</div>


### PR DESCRIPTION
## Summary
- Refresh backend theme variables, layout helpers, and components to align with Bootstrap 5/AdminLTE 4 and introduce new stat-card styles
- Rework the dashboard view to use modern cards, responsive tabs, and updated widgets for charts and the visitor map
- Update SmallBox markup and Flot realtime controls to match the new styling system

## Testing
- php -l backend/widgets/box/SmallBox.php
- php -l backend/widgets/chart/flot/Chart.php
- php -l modules/main/views/backend/default/index.php

------
https://chatgpt.com/codex/tasks/task_e_68daa4eb4138832e82639eb3e66c6607